### PR TITLE
Support both JDBC v3 and v2 driver 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: adopt
       - name: Download Athena JDBC v3 Driver
-        run: mkdir lib && curl -L -o lib/athena-v3.jar curl -L -O https://downloads.athena.us-east-1.amazonaws.com/drivers/JDBC/3.5.1/athena-jdbc-3.5.1-with-dependencies.jar
+        run: mkdir -p lib && curl -L -o lib/athena-v3.jar curl -L -O https://downloads.athena.us-east-1.amazonaws.com/drivers/JDBC/3.5.1/athena-jdbc-3.5.1-with-dependencies.jar
         shell: bash
       - name: Download Athena JDBC v2 Driver
-        run: mkdir lib && curl -L -o lib/athena-v2.jar https://downloads.athena.us-east-1.amazonaws.com/drivers/JDBC/SimbaAthenaJDBC-2.1.1.1000/AthenaJDBC42-2.1.1.1000.jar
+        run: mkdir -p lib && curl -L -o lib/athena-v2.jar https://downloads.athena.us-east-1.amazonaws.com/drivers/JDBC/SimbaAthenaJDBC-2.1.1.1000/AthenaJDBC42-2.1.1.1000.jar
         shell: bash
       - name: Test
         run: sbt -v -Dfile.encoding=UTF-8 ++${{ matrix.scala }} test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,11 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: adopt
-      - name: Download Athena JDBC Driver
-        run: mkdir lib && curl -L -o lib/AthenaJDBC42-2.1.1.1000.jar https://downloads.athena.us-east-1.amazonaws.com/drivers/JDBC/SimbaAthenaJDBC-2.1.1.1000/AthenaJDBC42-2.1.1.1000.jar
+      - name: Download Athena JDBC v3 Driver
+        run: mkdir lib && curl -L -o lib/athena-v3.jar curl -L -O https://downloads.athena.us-east-1.amazonaws.com/drivers/JDBC/3.5.1/athena-jdbc-3.5.1-with-dependencies.jar
+        shell: bash
+      - name: Download Athena JDBC v2 Driver
+        run: mkdir lib && curl -L -o lib/athena-v2.jar https://downloads.athena.us-east-1.amazonaws.com/drivers/JDBC/SimbaAthenaJDBC-2.1.1.1000/AthenaJDBC42-2.1.1.1000.jar
         shell: bash
       - name: Test
         run: sbt -v -Dfile.encoding=UTF-8 ++${{ matrix.scala }} test

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Library for using [Amazon Athena](https://aws.amazon.com/athena/) JDBC Driver wi
 
 ## setup
 
-- Download Athena JDBC 3.x driver
+- Download Athena JDBC driver
   - This library supports both Athena (https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver.html) and https://docs.aws.amazon.com/athena/latest/ug/jdbc-v2.html.  
     If you encounter problems with a particular version, please feel free to [report it](https://github.com/zaneli/scalikejdbc-athena/issues).
 ```sh

--- a/README.md
+++ b/README.md
@@ -6,9 +6,8 @@ Library for using [Amazon Athena](https://aws.amazon.com/athena/) JDBC Driver wi
 
 ## setup
 
-- Download [Athena JDBC 3.x driver](https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver.html)
-  - This library is basically depends on Athena JDBC 3.x driver.  
-    Choose your preferred or latest version in 3.x.  
+- Download Athena JDBC 3.x driver
+  - This library supports both Athena (https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver.html) and https://docs.aws.amazon.com/athena/latest/ug/jdbc-v2.html.  
     If you encounter problems with a particular version, please feel free to [report it](https://github.com/zaneli/scalikejdbc-athena/issues).
 ```sh
 > mkdir lib
@@ -28,6 +27,7 @@ libraryDependencies ++= Seq(
 - Configure the JDBC Driver Options on `resources/application.conf`
 
 ```
+# v3 driver
 athena {
   default {
     driver="com.amazon.athena.jdbc.AthenaDriver"
@@ -35,6 +35,19 @@ athena {
     readOnly="false"
     S3OutputLocation="s3://query-results-bucket/folder/"
     AwsCredentialsProviderClass="DefaultChain"
+    LogPath="logs/application.log"
+    LogLevel=3
+  }
+}
+
+# v2 driver
+athena {
+  default {
+    driver="com.simba.athena.jdbc.Driver"
+    url="jdbc:awsathena://AwsRegion={REGION}"
+    readOnly="false"
+    S3OutputLocation="s3://query-results-bucket/folder/"
+    AwsCredentialsProviderClass="com.simba.athena.amazonaws.auth.profile.ProfileCredentialsProvider"
     LogPath="logs/application.log"
     LogLevel=3
   }

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
 athena {
   default {
     driver="com.amazon.athena.jdbc.AthenaDriver"
-    url="jdbc:awsathena://AwsRegion={REGION}"
+    url="jdbc:athena://AwsRegion={REGION}"
     readOnly="false"
     S3OutputLocation="s3://query-results-bucket/folder/"
     AwsCredentialsProviderClass="DefaultChain"
@@ -81,7 +81,7 @@ DB.athena { implicit s =>
 athena {
   default {
     driver="com.amazon.athena.jdbc.AthenaDriver"
-    url="jdbc:awsathena://AwsRegion={REGION}"
+    url="jdbc:athena://AwsRegion={REGION}"
     readOnly="false"
     S3OutputLocationPrefix="s3://query-results-bucket/folder"
     AwsCredentialsProviderClass="DefaultChain"

--- a/README.md
+++ b/README.md
@@ -6,14 +6,15 @@ Library for using [Amazon Athena](https://aws.amazon.com/athena/) JDBC Driver wi
 
 ## setup
 
-- Download [Athena JDBC 2.x driver](https://docs.aws.amazon.com/athena/latest/ug/jdbc-v2.html)
-  - This library is basically depends on Athena JDBC 2.x driver.  
-    Choose your preferred or latest version in 2.x.  
+- Download [Athena JDBC 3.x driver](https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver.html)
+  - This library is basically depends on Athena JDBC 3.x driver.  
+    Choose your preferred or latest version in 3.x.  
     If you encounter problems with a particular version, please feel free to [report it](https://github.com/zaneli/scalikejdbc-athena/issues).
 ```sh
 > mkdir lib
-> curl -L -O https://downloads.athena.us-east-1.amazonaws.com/drivers/JDBC/SimbaAthenaJDBC-2.1.1.1000/AthenaJDBC42-2.1.1.1000.jar
-> mv AthenaJDBC42-2.1.1.1000.jar lib/
+> pushd lib
+> curl -L -O https://downloads.athena.us-east-1.amazonaws.com/drivers/JDBC/3.5.1/athena-jdbc-3.5.1-with-dependencies.jar
+> popd
 ```
 
 - Add library dependencies to sbt build settings
@@ -29,11 +30,11 @@ libraryDependencies ++= Seq(
 ```
 athena {
   default {
-    driver="com.simba.athena.jdbc.Driver"
+    driver="com.amazon.athena.jdbc.AthenaDriver"
     url="jdbc:awsathena://AwsRegion={REGION}"
     readOnly="false"
     S3OutputLocation="s3://query-results-bucket/folder/"
-    AwsCredentialsProviderClass="com.simba.athena.amazonaws.auth.profile.ProfileCredentialsProvider"
+    AwsCredentialsProviderClass="DefaultChain"
     LogPath="logs/application.log"
     LogLevel=3
   }
@@ -66,11 +67,11 @@ DB.athena { implicit s =>
 ```
 athena {
   default {
-    driver="com.simba.athena.jdbc.Driver"
+    driver="com.amazon.athena.jdbc.AthenaDriver"
     url="jdbc:awsathena://AwsRegion={REGION}"
     readOnly="false"
     S3OutputLocationPrefix="s3://query-results-bucket/folder"
-    AwsCredentialsProviderClass="com.simba.athena.amazonaws.auth.profile.ProfileCredentialsProvider"
+    AwsCredentialsProviderClass="DefaultChain"
     LogPath="logs/application.log"
     LogLevel=3
   }

--- a/src/main/scala/scalikejdbc/athena/Config.scala
+++ b/src/main/scala/scalikejdbc/athena/Config.scala
@@ -58,7 +58,7 @@ class Config(dbName: Any) {
   }
 }
 
-object Config {
+private object Config {
   val Url = "url"
   val Driver = "driver"
   val ReadOnly = "readOnly"

--- a/src/main/scala/scalikejdbc/athena/Config.scala
+++ b/src/main/scala/scalikejdbc/athena/Config.scala
@@ -120,7 +120,7 @@ object Config {
   val User = "User"
   val UID = "UID"
   val UseResultsetStreaming = "UseResultsetStreaming"
-  val Workgroup = "Workgroup"
+  val Workgroup = "WorkGroup"
 }
 
 class ConfigException(message: String) extends Exception(message)

--- a/src/main/scala/scalikejdbc/athena/Config.scala
+++ b/src/main/scala/scalikejdbc/athena/Config.scala
@@ -18,22 +18,10 @@ class Config(dbName: Any) {
 
   private[this] val config = ConfigFactory.load()
 
-  private[this] val optionalNames = Seq(
-    AwsCredentialsProviderArguments, AwsCredentialsProviderClass, BinaryColumnLength, ComplexTypeColumnLength,
-    ConnectionTest, ConnectTimeout, IdPHost, IdPPort, LogLevel, LogPath, MaxCatalogNameLength, MaxColumnNameLength,
-    MaxErrorRetry, MaxQueryExecutionPollingInterval, MaxSchemaNameLength, MaxStreamErrorRetry, MaxTableNameLength,
-    MetadataRetrievalMethod, NonProxyHosts, Password, PWD, PreemptiveBasicProxyAuth, PreferredRole, Profile,
-    ProxyDomain, ProxyHost, ProxyPort, ProxyPWD, ProxyUID, ProxyWorkstation, RowsToFetchPerBlock, S3OutputEncKMSKey,
-    S3OutputEncOption, Schema, SocketTimeout, SSLInsecure, StringColumnLength, UseArraySupport, UseAwsLogger,
-    User, UID, UseResultsetStreaming, Workgroup
-  )
-
-  private[this] val attributeNames = Seq(Url, Driver, ReadOnly, TimeZone, S3OutputLocation, S3OutputLocationPrefix) ++ optionalNames
-
   private[this] val map = if (config.hasPath(prefix)) {
-    config.getConfig(prefix).entrySet.asScala.map(_.getKey).collect {
-      case key if attributeNames.contains(key) =>
-        key -> config.getString(s"$prefix.$key")
+    config.getConfig(prefix).entrySet.asScala.map { entry =>
+      val key = entry.getKey
+      key -> config.getString(s"$prefix.$key")
     }.toMap
   } else {
     throw new ConfigException(s"no configuration setting: key=$prefix")
@@ -54,8 +42,9 @@ class Config(dbName: Any) {
       case (_, Some(v)) => p.setProperty(S3OutputLocation, s"$v/${UUID.randomUUID()}")
       case _ => throw new ConfigException(s"no configuration setting: key=$prefix.$S3OutputLocation, $prefix.$S3OutputLocationPrefix")
     }
-    optionalNames.foreach { name =>
-      map.get(name).foreach(value => p.setProperty(name, value))
+    map.foreach { entry =>
+      val (name, value) = entry
+      p.setProperty(name, value)
     }
     p
   }
@@ -78,49 +67,7 @@ object Config {
   val S3OutputLocation = "S3OutputLocation"
   val S3OutputLocationPrefix = "S3OutputLocationPrefix"
 
-  val AwsCredentialsProviderArguments = "AwsCredentialsProviderArguments"
-  val AwsCredentialsProviderClass = "AwsCredentialsProviderClass"
-  val BinaryColumnLength = "BinaryColumnLength"
-  val ComplexTypeColumnLength = "ComplexTypeColumnLength"
-  val ConnectionTest = "ConnectionTest"
-  val ConnectTimeout = "ConnectTimeout"
-  val IdPHost = "IdP_Host"
-  val IdPPort = "IdP_Port"
-  val LogLevel = "LogLevel"
-  val LogPath = "LogPath"
-  val MaxCatalogNameLength = "MaxCatalogNameLength"
-  val MaxColumnNameLength = "MaxColumnNameLength"
-  val MaxErrorRetry = "MaxErrorRetry"
-  val MaxQueryExecutionPollingInterval = "MaxQueryExecutionPollingInterval"
-  val MaxSchemaNameLength = "MaxSchemaNameLength"
-  val MaxStreamErrorRetry = "MaxStreamErrorRetry"
-  val MaxTableNameLength = "MaxTableNameLength"
-  val MetadataRetrievalMethod = "MetadataRetrievalMethod"
-  val NonProxyHosts = "NonProxyHosts"
-  val Password = "Password"
-  val PWD = "PWD"
-  val PreemptiveBasicProxyAuth = "PreemptiveBasicProxyAuth"
-  val PreferredRole = "preferred_role"
-  val Profile = "Profile"
-  val ProxyDomain = "ProxyDomain"
-  val ProxyHost = "ProxyHost"
-  val ProxyPort = "ProxyPort"
-  val ProxyPWD = "ProxyPWD"
-  val ProxyUID = "ProxyUID"
-  val ProxyWorkstation = "ProxyWorkstation"
-  val RowsToFetchPerBlock = "RowsToFetchPerBlock"
-  val S3OutputEncKMSKey = "S3OutputEncKMSKey"
-  val S3OutputEncOption = "S3OutputEncOption"
-  val Schema = "Schema"
-  val SocketTimeout = "SocketTimeout"
-  val SSLInsecure = "SSL_Insecure"
-  val StringColumnLength = "StringColumnLength"
-  val UseArraySupport = "UseArraySupport"
-  val UseAwsLogger = "UseAwsLogger"
   val User = "User"
-  val UID = "UID"
-  val UseResultsetStreaming = "UseResultsetStreaming"
-  val Workgroup = "WorkGroup"
 }
 
 class ConfigException(message: String) extends Exception(message)

--- a/src/main/scala/scalikejdbc/athena/Config.scala
+++ b/src/main/scala/scalikejdbc/athena/Config.scala
@@ -66,8 +66,6 @@ object Config {
 
   val S3OutputLocation = "S3OutputLocation"
   val S3OutputLocationPrefix = "S3OutputLocationPrefix"
-
-  val User = "User"
 }
 
 class ConfigException(message: String) extends Exception(message)

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -15,6 +15,16 @@ athena {
     AwsCredentialsProviderClass="DefaultChain"
     S3OutputLocationPrefix="s3://query-results-bucket/folder"
   }
+  v3params {
+    driver="com.amazon.athena.jdbc.AthenaDriver"
+    url="jdbc:athena://AwsRegion=ap-southeast-1"
+    readOnly="true"
+    timeZone="UTC"
+    AwsCredentialsProviderClass="DataZoneIdc"
+    DataZoneEnvironmentId="123"
+    DataZoneDomainRegion="us-west-2"
+    S3OutputLocationPrefix="s3://query-results-bucket/folder"
+  }
   duplicated {
     driver="com.amazon.athena.jdbc.AthenaDriver"
     url="jdbc:athena://AwsRegion=us-west-2"

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -39,4 +39,15 @@ athena {
     S3OutputLocation="s3://query-results-bucket/folder/"
     LogPath="logs/application.log"
   }
+  v2 {
+    default {
+        driver="com.simba.athena.jdbc.Driver"
+        url="jdbc:awsathena://AwsRegion=us-east-2"
+        readOnly="false"
+        S3OutputLocation="s3://query-results-bucket/folder/"
+        AwsCredentialsProviderClass="com.simba.athena.amazonaws.auth.profile.ProfileCredentialsProvider"
+        LogPath="logs/application.log"
+        LogLevel=3
+    }
+  }
 }

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,31 +1,31 @@
 athena {
   default {
-    driver="com.simba.athena.jdbc.Driver"
-    url="jdbc:awsathena://AwsRegion=us-east-2"
+    driver="com.amazon.athena.jdbc.AthenaDriver"
+    url="jdbc:athena://AwsRegion=us-east-2"
     readOnly="false"
-    AwsCredentialsProviderClass="com.simba.athena.amazonaws.auth.profile.ProfileCredentialsProvider"
+    AwsCredentialsProviderClass="DefaultChain"
     S3OutputLocation="s3://query-results-bucket/folder/"
     LogPath="logs/application.log"
   }
   athena {
-    driver="com.simba.athena.jdbc.Driver"
-    url="jdbc:awsathena://AwsRegion=ap-southeast-1"
+    driver="com.amazon.athena.jdbc.AthenaDriver"
+    url="jdbc:athena://AwsRegion=ap-southeast-1"
     readOnly="true"
     timeZone="UTC"
-    AwsCredentialsProviderClass="com.simba.athena.amazonaws.auth.profile.ProfileCredentialsProvider"
+    AwsCredentialsProviderClass="DefaultChain"
     S3OutputLocationPrefix="s3://query-results-bucket/folder"
   }
   duplicated {
-    driver="com.simba.athena.jdbc.Driver"
-    url="jdbc:awsathena://AwsRegion=us-west-2"
-    AwsCredentialsProviderClass="com.simba.athena.amazonaws.auth.profile.ProfileCredentialsProvider"
+    driver="com.amazon.athena.jdbc.AthenaDriver"
+    url="jdbc:athena://AwsRegion=us-west-2"
+    AwsCredentialsProviderClass="DefaultChain"
     S3OutputLocation="s3://query-results-bucket/folder/"
     S3OutputLocationPrefix="s3://query-results-bucket/folder"
   }
   h2 {
     driver="org.h2.Driver"
     url="jdbc:h2:mem:athena;DB_CLOSE_DELAY=-1"
-    AwsCredentialsProviderClass="com.simba.athena.amazonaws.auth.profile.ProfileCredentialsProvider"
+    AwsCredentialsProviderClass="DefaultChain"
     S3OutputLocation="s3://query-results-bucket/folder/"
     LogPath="logs/application.log"
   }

--- a/src/test/scala/scalikejdbc/athena/ConfigSpec.scala
+++ b/src/test/scala/scalikejdbc/athena/ConfigSpec.scala
@@ -33,7 +33,6 @@ class ConfigSpec extends AnyFunSpec with OptionValues {
       assert(config.options.getProperty("DataZoneDomainRegion") === "us-west-2")
     }
     it("v2") {
-      // This test ensures that new config parameters is supported
       val config = new Config("v2.default")
       assert(config.url === "jdbc:awsathena://AwsRegion=us-east-2")
       assert(config.options.getProperty("S3OutputLocation") === "s3://query-results-bucket/folder/")

--- a/src/test/scala/scalikejdbc/athena/ConfigSpec.scala
+++ b/src/test/scala/scalikejdbc/athena/ConfigSpec.scala
@@ -8,7 +8,7 @@ class ConfigSpec extends AnyFunSpec with OptionValues {
   describe("Config") {
     it("default db") {
       val config = new Config("default")
-      assert(config.url === "jdbc:awsathena://AwsRegion=us-east-2")
+      assert(config.url === "jdbc:athena://AwsRegion=us-east-2")
       assert(config.options.getProperty("S3OutputLocation") === "s3://query-results-bucket/folder/")
       assert(config.options.getProperty("LogPath") === "logs/application.log")
       assert(config.getTmpStagingDir.isEmpty)
@@ -17,7 +17,7 @@ class ConfigSpec extends AnyFunSpec with OptionValues {
     }
     it("named db") {
       val config = new Config("athena")
-      assert(config.url === "jdbc:awsathena://AwsRegion=ap-southeast-1")
+      assert(config.url === "jdbc:athena://AwsRegion=ap-southeast-1")
       assert(config.options.getProperty("S3OutputLocation") !== "s3://query-results-bucket/folder")
       assert(config.options.getProperty("S3OutputLocation").startsWith("s3://query-results-bucket/folder") === true)
       assert(config.options.containsKey("LogPath") === false)

--- a/src/test/scala/scalikejdbc/athena/ConfigSpec.scala
+++ b/src/test/scala/scalikejdbc/athena/ConfigSpec.scala
@@ -32,6 +32,16 @@ class ConfigSpec extends AnyFunSpec with OptionValues {
       assert(config.options.getProperty("DataZoneEnvironmentId") === "123")
       assert(config.options.getProperty("DataZoneDomainRegion") === "us-west-2")
     }
+    it("v2") {
+      // This test ensures that new config parameters is supported
+      val config = new Config("v2.default")
+      assert(config.url === "jdbc:awsathena://AwsRegion=us-east-2")
+      assert(config.options.getProperty("S3OutputLocation") === "s3://query-results-bucket/folder/")
+      assert(config.options.getProperty("LogPath") === "logs/application.log")
+      assert(config.getTmpStagingDir.isEmpty)
+      assert(config.readOnly.value === false)
+      assert(config.timeZone.isEmpty)
+    }
     it("invalid settings") {
       val config = new Config("duplicated")
       assertThrows[ConfigException](config.options)

--- a/src/test/scala/scalikejdbc/athena/ConfigSpec.scala
+++ b/src/test/scala/scalikejdbc/athena/ConfigSpec.scala
@@ -25,6 +25,13 @@ class ConfigSpec extends AnyFunSpec with OptionValues {
       assert(config.readOnly.value === true)
       assert(config.timeZone.value === "UTC")
     }
+    it("v3") {
+      // This test ensures that new config parameters is supported
+      val config = new Config("v3params")
+      assert(config.url === "jdbc:athena://AwsRegion=ap-southeast-1")
+      assert(config.options.getProperty("DataZoneEnvironmentId") === "123")
+      assert(config.options.getProperty("DataZoneDomainRegion") === "us-west-2")
+    }
     it("invalid settings") {
       val config = new Config("duplicated")
       assertThrows[ConfigException](config.options)


### PR DESCRIPTION
Closes #16 

- Pass-through all config parameters to JDBC driver. I believe this is future-proof and simple solution to support both v3 and v2.
- Updated README to include both v2 and v3 config example
- Confirmed this works both with v2 and v3
    - Updated CI to test with v2 and v3

## Connection Parameters

I've compared [v3 doc](https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver-connection-parameters.html) with [v2 doc](https://downloads.athena.us-east-1.amazonaws.com/drivers/JDBC/SimbaAthenaJDBC-2.2.1.1000/docs/Simba+Amazon+Athena+JDBC+Connector+Install+and+Configuration+Guide.pdf).

There are several breaking change: Some v2 parameters does not work on v3
Many parameters were added in v3, such as [DataZone IdC credentials](https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver-datazone-idc.html). 
So I think pass-through is the simplest, most robust solution to support both v2 and v3.

- ❌: breaking change due to rename
- ⚠️: v2/v3 compatible, but deprecated in v3 
- ❓: I can not find a corresponding parameter in v3 doc. Maybe it still work, but not tested on my end.
- 🐛 | Found in v2 doc, but not implemented in scalikejdbc-athena

JDBC Driver v2 | v3 alias | v3 preferred
---|---|---
S3OutputLocation | S3OutputLocation  ⚠️ | [OutputLocation](https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver-basic-connection-parameters.html#jdbc-v3-driver-output-location)
AwsCredentialsProviderArguments | ❓  | ❓ 
AwsCredentialsProviderClass | AwsCredentialsProviderClass ⚠️  | [CredentialsProvider](https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver-default-credentials.html#jdbc-v3-driver-credentials-provider)
BinaryColumnLength | ❓| ❓ 
ComplexTypeColumnLength |❓| ❓
ConnectionTest | - | [ConnectionTest](https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver-advanced-connection-parameters.html#jdbc-v3-driver-connection-test)
ConnectTimeout | ❌ | [NetworkTimeoutMillis](https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver-advanced-connection-parameters.html#jdbc-v3-driver-connection-test)
IdP_Host | IdP_Host  ⚠️ | [AdfsHostName](https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver-adfs-credentials.html#jdbc-v3-driver-adfs-credentials-adfshostname)
IdP_Port | IdP_Port  ⚠️ | [AdfsPortNumber](https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver-adfs-credentials.html#jdbc-v3-driver-adfs-credentials-adfsportnumber)
LogLevel | - | [LogLevel](https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver-advanced-connection-parameters.html#jdbc-v3-driver-logging-parameters)
LogPath | - | [LogPath](https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver-advanced-connection-parameters.html#jdbc-v3-driver-logging-parameters)
MaxCatalogNameLength |❓| ❓ 
MaxColumnNameLength |❓| ❓ 
MaxErrorRetry | MaxErrorRetry ⚠️  | [NumRetries](https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver-advanced-connection-parameters.html#jdbc-v3-driver-number-of-retries)
MaxQueryExecutionPollingInterval |MaxQueryExecutionPollingInterval ⚠️ |MaxQueryExecutionPollingIntervalMillis
MinQueryExecutionPollingInterval 🐛  | MinQueryExecutionPollingInterval ⚠️ | MinQueryExecutionPollingIntervalMillis
MaxSchemaNameLength | ❓ | ❓ 
MaxStreamErrorRetry | ❓ | ❓ 
MaxTableNameLength |❓ | ❓ 
MetadataRetrievalMethod |❓ | ❓ 
NonProxyHosts | NonProxyHosts | [ProxyExemptHosts](https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver-advanced-connection-parameters.html#jdbc-v3-driver-proxy-configuration-parameters)
Password | Password | SecretAccessKey
PWD |❓ | ❓ 
PreemptiveBasicProxyAuth |❓ | ❓ 
preferred_role | preferred_role ⚠️ | [PreferredRole](https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver-adfs-credentials.html#jdbc-v3-driver-adfs-credentials-preferred-role)
Profile | ❌ | ProfileName
ProxyDomain | ❓ | ❓ 
ProxyHost | - | [ProxyHost](https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver-advanced-connection-parameters.html#jdbc-v3-driver-proxy-configuration-parameters)
ProxyPort | - | [ProxyPort](https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver-advanced-connection-parameters.html#jdbc-v3-driver-proxy-configuration-parameters)
ProxyPWD | ProxyPWD ⚠️ | [ProxyPassword](https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver-advanced-connection-parameters.html#jdbc-v3-driver-proxy-configuration-parameters)
ProxyUID | ProxyUID ⚠️ | ProxyUsername
ProxyWorkstation | ❓ | ❓ 
QueryExecutionPollingIntervalMultiplier 🐛 | - | QueryExecutionPollingIntervalMultiplier
RowsToFetchPerBlock | RowsToFetchPerBlock ⚠️  | [FetchSize](https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver-advanced-connection-parameters.html#jdbc-v3-driver-result-fetching-parameters)
S3OutputEncKMSKey | S3OutputEncKMSKey ⚠️  | [KmsKey](https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver-advanced-connection-parameters.html#jdbc-v3-driver-result-fetching-parameters)
S3OutputEncOption | S3OutputEncOption ⚠️ | [EncryptionOption](https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver-advanced-connection-parameters.html#jdbc-v3-driver-result-fetching-parameters)
Schema | Schema | [Database](https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver-basic-connection-parameters.html)
SocketTimeout | ❓  | ❓ 
SSL_Insecure | ❓  | ❓ 
StringColumnLength | ❓  | ❓ 
UseArraySupport |❓  | ❓ 
UseAwsLogger |❓  | ❓ 
User |AccessKeyId | User
UID | UID | [User](https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver-adfs-credentials.html)
UseResultsetStreaming |❓  | ❓ 
Workgroup | ❌  | WorkGroup