### PR TITLE
Fix CI: install missing sbt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: adopt
+      - uses: sbt/setup-sbt@v1
       - name: Download Athena JDBC v3 Driver
         run: mkdir -p lib && curl -L -o lib/athena-v3.jar curl -L -O https://downloads.athena.us-east-1.amazonaws.com/drivers/JDBC/3.5.1/athena-jdbc-3.5.1-with-dependencies.jar
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           distribution: adopt
       - uses: sbt/setup-sbt@v1
       - name: Download Athena JDBC v3 Driver
-        run: mkdir -p lib && curl -L -o lib/athena-v3.jar curl -L -O https://downloads.athena.us-east-1.amazonaws.com/drivers/JDBC/3.5.1/athena-jdbc-3.5.1-with-dependencies.jar
+        run: mkdir -p lib && curl -L -o lib/athena-v3.jar https://downloads.athena.us-east-1.amazonaws.com/drivers/JDBC/3.5.1/athena-jdbc-3.5.1-with-dependencies.jar
         shell: bash
       - name: Download Athena JDBC v2 Driver
         run: mkdir -p lib && curl -L -o lib/athena-v2.jar https://downloads.athena.us-east-1.amazonaws.com/drivers/JDBC/SimbaAthenaJDBC-2.1.1.1000/AthenaJDBC42-2.1.1.1000.jar

--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ Library for using [Amazon Athena](https://aws.amazon.com/athena/) JDBC Driver wi
     If you encounter problems with a particular version, please feel free to [report it](https://github.com/zaneli/scalikejdbc-athena/issues).
 ```sh
 > mkdir lib
-> pushd lib
-> curl -L -O https://downloads.athena.us-east-1.amazonaws.com/drivers/JDBC/3.5.1/athena-jdbc-3.5.1-with-dependencies.jar
-> popd
+> curl -L -o lib/athena-vjdbc-3.5.1-with-dependencies.jar https://downloads.athena.us-east-1.amazonaws.com/drivers/JDBC/3.5.1/athena-jdbc-3.5.1-with-dependencies.jar
 ```
 
 - Add library dependencies to sbt build settings


### PR DESCRIPTION
- Install sbt explictly, since sbt is no longer installed in ubuntu-latest 😢 
- Fix curl option 


Ref. https://github.com/actions/runner-images/issues/10767